### PR TITLE
Remove PHP7 type declaration and dependency on xml solution pack.

### DIFF
--- a/includes/object.inc
+++ b/includes/object.inc
@@ -15,7 +15,7 @@ class IslandoraBatchWithDerivsObject extends IslandoraBatchObject {
   /**
    * Constructor.
    */
-  public function __construct(IslandoraTuque $connection, string $key_datastream_path, $batch_parameters) {
+  public function __construct(IslandoraTuque $connection, $key_datastream_path, $batch_parameters) {
     parent::__construct(NULL, $connection->repository);
 
     $this->keyDsFilePath = $key_datastream_path;

--- a/islandora_batch_with_derivs.drush.inc
+++ b/islandora_batch_with_derivs.drush.inc
@@ -14,7 +14,7 @@ function islandora_batch_with_derivs_drush_command() {
   $items['islandora_batch_with_derivs_preprocess'] = array(
     'aliases' => array('ibwd'),
     'description' => 'Preprocess Islandora objects with derivatives into batch queue entries.',
-    'drupal dependencies' => array('islandora_batch', 'islandora_solution_pack_xml'),
+    'drupal dependencies' => array('islandora_batch'),
     'options' => array(
       'scan_target' => array(
         'description' => 'The target directory to scan.',


### PR DESCRIPTION
No ticket because it's not core; I tried to use this module but got a couple of errors.

First it's dependent on islandora_solution_pack_xml.
Second it used a type declaration that only works in PHP 7+

# What does this Pull Request do?

Removes dependency on XML solution pack and PHP 7.

# What's new?
Removed dependency from drush file and a type declaration.

# How should this be tested?

Try to use drush islandora_batch_with_derivs_preprocess with PHP 5 and no XML sp enabled.

* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No - wasn't a documented dependency
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  NO
* Could this change impact execution of existing code? NO

# Interested parties
@mjordan 